### PR TITLE
Modification de la gestion des popups

### DIFF
--- a/01_telechargement_data.R
+++ b/01_telechargement_data.R
@@ -342,10 +342,12 @@ produire_graph_pour_une_station <-
       scale_fill_manual(values = couleurs, breaks = levels(prov$modalite), name = 'Modalités') +
       scale_shape_manual(values = c(21,22),name = 'Type campagne') +
       scale_size_manual(values = c(5,10),name = 'Type campagne') +
-      scale_y_continuous(breaks = 1:12, labels = 1:12) +
+      scale_y_continuous(breaks = 1:12, labels = 1:12, limits = c(1, 12)) +
       scale_x_continuous(breaks = min(prov$Annee, na.rm = T):max(prov$Annee, na.rm = T),
                          labels = min(prov$Annee, na.rm = T):max(prov$Annee, na.rm = T)) +
-      labs(x = "", y = "Mois", title = nom_station) +
+      labs(x = "", y = "Mois", 
+           title = unique(prov$libelle_station),
+           subtitle = unique(prov$code_station)) +
       theme_bw() +
       theme(title = element_text(face = 'bold'),
             axis.text.x = element_text(size=10),

--- a/01_telechargement_data.R
+++ b/01_telechargement_data.R
@@ -359,6 +359,8 @@ produire_graph_pour_une_station <-
     graph1
   }
 
+list.files("www/png", recursive = TRUE, full.names = TRUE) %>% 
+  purrr::walk(file.remove)
 
 ### -> graphiques 3modalités
 graphiques_int_3mod <- 
@@ -369,6 +371,20 @@ graphiques_int_3mod <-
 
 names(graphiques_int_3mod) <- stations_onde_geo_usuelles$code_station
 
+purrr::walk(
+  names(graphiques_int_3mod),
+  function(station) {
+    ggplot2::ggsave(
+      plot = graphiques_int_3mod[[station]],
+      filename = paste0("www/png/3mod/", station, ".png"),
+      width = 14,
+      height = 10,
+      units = "cm",
+      dpi = 150
+    )
+  }
+  )
+
 ### -> graphiques 4modalités
 graphiques_int_4mod <- 
   purrr::map(.x = stations_onde_geo_usuelles$code_station, 
@@ -377,6 +393,20 @@ graphiques_int_4mod <-
              onde_df = onde_periode)
 
 names(graphiques_int_4mod) <- stations_onde_geo_usuelles$code_station
+
+purrr::walk(
+  names(graphiques_int_4mod),
+  function(station) {
+    ggplot2::ggsave(
+      plot = graphiques_int_4mod[[station]],
+      filename = paste0("www/png/4mod/", station, ".png"),
+      width = 14,
+      height = 10,
+      units = "cm",
+      dpi = 150
+    )
+  }
+)
 
 #####################################
 # Mise en forme des tableaux pour les graphiques bilan
@@ -473,8 +503,8 @@ propluvia <-
 #####################################
 # Sauvegarde des objets pour page Rmd
 save(stations_onde_geo_usuelles, 
-     graphiques_int_3mod,
-     graphiques_int_4mod,
+     # graphiques_int_3mod,
+     # graphiques_int_4mod,
      onde_dernieres_campagnes,
      onde_dernieres_campagnes_usuelles, 
      onde_dernieres_campagnes_comp,

--- a/assets/template.Rmd
+++ b/assets/template.Rmd
@@ -194,7 +194,7 @@ popups_3mod <- file.path("www/png/3mod", list.files(path = "../www/png/3mod/", p
           # popup = leafpop::popupGraph(graphiques_int_3mod, width = 400, height = 350),
           popup = leafpop::popupImage(
             popups_3mod[stations_onde_geo_map1$code_station],
-            height = 350, width = 400
+            height = 290, width = 400
           ),
           col.regions = stations_onde_geo_map1$Couleur, homebutton = T)) %>% 
   finalize_map(bbox = depts_sel_bbox)
@@ -221,7 +221,7 @@ popups_4mod <- file.path("www/png/4mod", list.files(path = "../www/png/4mod/", p
           zcol = "label_point",
           popup = leafpop::popupImage(
             popups_4mod[stations_onde_geo_map1$code_station],
-            height = 350, width = 400
+            height = 290, width = 400
           ),
           # popup = leafpop::popupGraph(graphiques_int_4mod, width = 400, height = 350),
           col.regions = stations_onde_geo_map1$Couleur, homebutton = T)) %>% 

--- a/assets/template.Rmd
+++ b/assets/template.Rmd
@@ -176,13 +176,26 @@ map_situation <-
 ### Typologie nationale
 
 ```{r cartoDynamique 3mod, fig.height = 7, fig.width = 11, align = "center", warning = FALSE}
+popups_3mod <- file.path("www/png/3mod", list.files(path = "../www/png/3mod/", pattern = ".png")) %>% 
+  (function(x) {
+    names(x) <- x %>% 
+      stringr::str_remove_all(pattern = "www/png/3mod/") %>% 
+      stringr::str_remove_all(pattern = ".png")
+    
+    x
+  })
+
 (map_situation +
   mapview(stations_onde_geo_map1, cex = "pourcentage_assecs",
           layer.name = "Assecs",
           legend = FALSE,
           alpha.regions = 0.9,
           zcol = "label_point",
-          popup = leafpop::popupGraph(graphiques_int_3mod, width = 400, height = 350),
+          # popup = leafpop::popupGraph(graphiques_int_3mod, width = 400, height = 350),
+          popup = leafpop::popupImage(
+            popups_3mod[stations_onde_geo_map1$code_station],
+            height = 350, width = 400
+          ),
           col.regions = stations_onde_geo_map1$Couleur, homebutton = T)) %>% 
   finalize_map(bbox = depts_sel_bbox)
   
@@ -191,13 +204,26 @@ map_situation <-
 ### Typologie départementale
 
 ```{r cartoDynamique 4mod, fig.height = 7, fig.width = 11, align = "center", warning = FALSE}
+popups_4mod <- file.path("www/png/4mod", list.files(path = "../www/png/4mod/", pattern = ".png")) %>% 
+  (function(x) {
+    names(x) <- x %>% 
+      stringr::str_remove_all(pattern = "www/png/4mod/") %>% 
+      stringr::str_remove_all(pattern = ".png")
+    
+    x
+  })
+
 (map_situation +
   mapview(stations_onde_geo_map1, cex = "pourcentage_assecs",
           layer.name = "Assecs",
           legend = FALSE,
           alpha.regions = 0.9,
           zcol = "label_point",
-          popup = leafpop::popupGraph(graphiques_int_4mod, width = 400, height = 350),
+          popup = leafpop::popupImage(
+            popups_4mod[stations_onde_geo_map1$code_station],
+            height = 350, width = 400
+          ),
+          # popup = leafpop::popupGraph(graphiques_int_4mod, width = 400, height = 350),
           col.regions = stations_onde_geo_map1$Couleur, homebutton = T)) %>% 
   finalize_map(bbox = depts_sel_bbox)
 


### PR DESCRIPTION
Les graphiques des popups ne sont plus enregistrés en dur dans la page html mais dans des fichiers images séparés. Cela permet d'alléger fortement la page créée et de permettre son déploiement même pour les grandes régions