### PR TITLE
Corrections du graphe sur les assecs successifs

### DIFF
--- a/01_telechargement_data.R
+++ b/01_telechargement_data.R
@@ -46,7 +46,8 @@ campagnes <- map_df(.x = dpt_sel,
                         date_campagne_max = date_jour
                       )
                     )) %>% 
-  mutate(code_campagne = as.character(code_campagne))
+  mutate(code_campagne = as.character(code_campagne)) %>% 
+  dplyr::distinct()
 
 #### infos stations
 param_stations <- 
@@ -58,7 +59,8 @@ stations <- map_df(.x = dpt_sel,
                    function(x) get_ecoulement_stations(
                      list(code_departement = x,
                           fields = param_stations)
-                   ))
+                   )) %>% 
+  dplyr::distinct()
 
 #### infos observations
 param_obs <- 
@@ -73,7 +75,8 @@ observations <- map_df(.x = dpt_sel,
                               date_observation_max = date_jour,
                               fields = param_obs)
                        )) %>% 
-  mutate(code_campagne = as.character(code_campagne))
+  mutate(code_campagne = as.character(code_campagne)) %>% 
+  dplyr::distinct()
 
 ### Assemblage des données stations, observations, campagnes ----
 onde_df <-
@@ -498,12 +501,14 @@ heatmap_df_dep <-
 
 duree_assecs_df <-
   onde_periode %>% 
-  filter(libelle_type_campagne == 'usuelle') %>% 
-  dplyr::select(code_station, libelle_station, Annee, Mois, lib_ecoul3mod, date_campagne) %>% 
-  dplyr::filter(Mois %in% c("05","06", "07", "08", "09")) %>% 
-  mutate(mois_num = lubridate::month(date_campagne)) %>% 
+  filter(
+    libelle_type_campagne == 'usuelle',
+    Mois %in% c("05","06", "07", "08", "09")
+    ) %>% 
+  dplyr::distinct(code_station, libelle_station, Annee, Mois, lib_ecoul3mod) %>% 
+  mutate(mois_num = as.numeric(Mois)) %>% 
   as_tibble() %>%
-  arrange(code_station, date_campagne) %>% 
+  arrange(code_station, Annee, Mois) %>% 
   group_by(code_station,Annee, ID = data.table::rleid(code_station,lib_ecoul3mod == 'Assec' )) %>%
   mutate(mois_assec_consec = ifelse(lib_ecoul3mod == 'Assec', row_number(), 0L)) %>% 
   group_by(Annee,code_station) %>% 
@@ -519,20 +524,20 @@ duree_assecs_df <-
 
 duree_assecs_df_dep <-
   onde_periode %>% 
-  filter(libelle_type_campagne == 'usuelle') %>% 
-  dplyr::filter(Mois %in% c("05","06", "07", "08", "09")) %>% 
+  filter(
+    libelle_type_campagne == 'usuelle',
+    Mois %in% c("05","06", "07", "08", "09")
+  ) %>% 
   dplyr::group_by(code_departement) %>% 
   dplyr::group_split(.keep = TRUE) %>% 
   purrr::map_df(
     function(df_dep) {
       df_dep %>% 
-        dplyr::select(
-          code_departement, code_station, libelle_station, 
-          Annee, Mois, lib_ecoul3mod, date_campagne
-          ) %>% 
-        mutate(mois_num = lubridate::month(date_campagne)) %>% 
+        dplyr::distinct(code_departement, code_station, libelle_station, 
+                        Annee, Mois, lib_ecoul3mod) %>% 
+        mutate(mois_num = as.numeric(Mois)) %>% 
         as_tibble() %>%
-        arrange(code_station, date_campagne) %>% 
+        arrange(code_station, Annee, Mois) %>% 
         group_by(
           code_station,
           Annee, 

--- a/assets/template.Rmd
+++ b/assets/template.Rmd
@@ -369,9 +369,17 @@ plot_heatmap(heatmap_df)
 ```{r}
 plot_assecs_consecutifs <- function(df_assecs, round_prec = 1) {
   df_assecs %>%
+    ungroup() %>% 
     filter(label != '0 mois') %>% 
+    mutate(label = factor(
+      label, 
+      levels = c(
+        paste0(5:2, " mois consécutifs"), "1 mois"
+        )
+      )
+      ) %>% 
     ggplot() + 
-    aes(x = as.factor(Annee), y = pct, fill = max_nb_mois_assec) +
+    aes(x = as.factor(Annee), y = pct, fill = label) +
     geom_bar(stat = "identity") +
     geom_text(
       aes(y = pct, label = nb_station), 
@@ -380,11 +388,16 @@ plot_assecs_consecutifs <- function(df_assecs, round_prec = 1) {
       position = position_stack(vjust = 0.5),
       show.legend = FALSE
       ) +
-    scale_fill_brewer(
-      "Nombre de campagnes\navec assec (mai-septembre)", 
-      palette = "YlOrRd",
-      direction = -1, 
-      labels=sort(unique(duree_assecs_df$label),decreasing = T)) +
+    scale_fill_manual(
+      values = c(
+        "1 mois" = "#FFFFB2FF",
+        "2 mois consécutifs" = "#FECC5CFF",
+        "3 mois consécutifs" = "#FD8D3CFF",
+        "4 mois consécutifs" = "#F03B20FF",
+        "5 mois consécutifs" = "#BD0026FF"
+          ),
+      drop = FALSE
+      ) +
     scale_y_continuous(labels = scales::percent_format(round_prec)) +
     ggtitle("Proportions et nombre de stations concernées") +
     theme_bw() +


### PR DESCRIPTION
Des doublons faussaient le calcul du nombre de mois consécutifs en assec (voir issue #20 ). Les modifications proposées permettent de les écarter (mais ne résolvent pas le problème à la source). Une gestion plus explicite des couleurs attribuées aux catégories est également proposée pour toujours avoir la même échelle de couleurs