### PR TITLE
Forcer la mise-à-jour des données quand le code est modifié

### DIFF
--- a/.github/workflows/sync_deploy.yaml
+++ b/.github/workflows/sync_deploy.yaml
@@ -54,7 +54,7 @@ jobs:
         
       - name: Verifier maj
         run: |
-          Rscript "01_verifier_maj.R"
+          Rscript "01_forcer_maj.R"
           
       - name: Telechargement donnees
         run: |

--- a/01_forcer_maj.R
+++ b/01_forcer_maj.R
@@ -1,0 +1,19 @@
+##%##################%##
+#                      #
+#### Vérifier MAJ   ####
+#                      #
+##%##################%##
+
+import::from("dplyr", '%>%')
+
+date_jour <- as.character(format(Sys.time(),"%Y-%m-%d"))
+date_jour_heure <- as.character(format(Sys.time(),"%Y-%m-%d_%Hh%m"))
+
+source("_config.R")
+
+to_update <- TRUE
+
+save(to_update, date_jour, date_jour_heure, file = "data/onde_data/to_update.rda")
+  
+print(switch(as.character(to_update), `TRUE` = "Mise-à-jour requise", `FALSE` = "Pas de mise-à-jour requise"))
+


### PR DESCRIPTION
Des modifications du code peuvent engendrer la création de nouveaux objets. Si après vérification des données, la mise-à-jour n'est pas nécessaire, ces nouveaux objets ne sont pas crées et cela entraîne l'échec de l'exécution du nouveau code.
Les modifications force la mise-à-jour des données à chaque fois qu'une modification du code est intégrée dans la branche deploy depuis la branche principale