### PR TITLE
Changement de procédure d'installation des packages R

### DIFF
--- a/00_installation_packages.R
+++ b/00_installation_packages.R
@@ -1,5 +1,3 @@
 ## Dépendances 
 
-devtools::install_github("richaben/ondetools")
-devtools::install_github("inrae/hubeau")
-install.packages(c("tidyverse", "purrr", "sf", "mapview", "leaflet", "leaflet.extras", "ggrepel", "glue", "forcats", "scales", "data.table", "lubridate", "stringr", "tidyr", "ggplot2", "knitr", "rmarkdown", "htmltools", "leafem"))
+pak::pkg_install(c("richaben/ondetools", "inrae/hubeau", "tidyverse", "purrr", "sf", "mapview", "leaflet", "leaflet.extras", "ggrepel", "glue", "forcats", "scales", "data.table", "lubridate", "stringr", "tidyr", "ggplot2", "knitr", "rmarkdown", "htmltools", "leafem", "png", "webp"))


### PR DESCRIPTION
Suite à des problèmes d'exécution des GH action en lien avec l'installation de packages (https://github.com/richaben/PRR_ONDE/issues/54), passage de l'installation des packages via le package {pak} qui est par ailleurs utilisé dans GH action